### PR TITLE
Fix runtime errors caused by literal newline characters

### DIFF
--- a/client/src/components/CSVPreview.tsx
+++ b/client/src/components/CSVPreview.tsx
@@ -46,7 +46,8 @@ export const CSVPreview: React.FC<CSVPreviewProps> = ({
   onCancel,
   className = ''
 }) => {
-  const { t } = FEATURES.I18N_ENABLED ? useTranslation() : mockUseTranslation();\n  const displayRecords = records.slice(0, 5); // Show first 5 records
+  const { t } = FEATURES.I18N_ENABLED ? useTranslation() : mockUseTranslation();
+  const displayRecords = records.slice(0, 5); // Show first 5 records
   const hasMoreRecords = records.length > 5;
 
   return (

--- a/client/src/components/CSVPreviewModal.tsx
+++ b/client/src/components/CSVPreviewModal.tsx
@@ -45,7 +45,8 @@ export const CSVPreviewModal: React.FC<CSVPreviewModalProps> = ({
   onCancel,
   isOpen
 }) => {
-  const { t } = FEATURES.I18N_ENABLED ? useTranslation() : mockUseTranslation();\n  if (!isOpen) return null;
+  const { t } = FEATURES.I18N_ENABLED ? useTranslation() : mockUseTranslation();
+  if (!isOpen) return null;
 
   const displayRecords = records.slice(0, 10); // Show first 10 records
   const hasMoreRecords = records.length > 10;


### PR DESCRIPTION
Fixed literal \n characters in CSVPreview.tsx and CSVPreviewModal.tsx that were causing React/Vite runtime parsing errors with Unicode escape sequences.

The errors were:
- CSVPreview.tsx:49:81 - Expecting Unicode escape sequence \uXXXX
- CSVPreviewModal.tsx:48:81 - Expecting Unicode escape sequence \uXXXX

🤖 Generated with [Claude Code](https://claude.ai/code)